### PR TITLE
Bugfix: Avoid manipulation of z coord of first waypoint in RouteScenario

### DIFF
--- a/leaderboard/leaderboard/scenarios/route_scenario.py
+++ b/leaderboard/leaderboard/scenarios/route_scenario.py
@@ -144,6 +144,7 @@ class RouteScenario(BasicScenario):
     def _spawn_ego_vehicle(self):
         """Spawn the ego vehicle at the first waypoint of the route"""
         elevate_transform = self.route[0][0]
+        elevate_transform = carla.Transform(elevate_transform.location, elevate_transform.rotation) # Copy
         elevate_transform.location.z += 0.5
 
         ego_vehicle = CarlaDataProvider.request_new_actor('vehicle.lincoln.mkz_2020',

--- a/scenario_runner/srunner/scenarios/route_scenario.py
+++ b/scenario_runner/srunner/scenarios/route_scenario.py
@@ -120,6 +120,7 @@ class RouteScenario(BasicScenario):
     def _spawn_ego_vehicle(self):
         """Spawn the ego vehicle at the first waypoint of the route"""
         elevate_transform = self.route[0][0]
+        elevate_transform = carla.Transform(elevate_transform.location, elevate_transform.rotation) # Copy
         elevate_transform.location.z += 0.5
 
         ego_vehicle = CarlaDataProvider.request_new_actor('vehicle.lincoln.mkz_2017',


### PR DESCRIPTION
The z component of the first route waypoint gets manipulated, when the ego vehicle is spawned. This is clearly not intended. I added a safe copy operation instead.